### PR TITLE
Add support for Comments Region shortcut (⌘/), automatic indentation, symbolication, and shell-script syntax coloring

### DIFF
--- a/Queries/highlights.scm
+++ b/Queries/highlights.scm
@@ -1,6 +1,5 @@
 [
   "(" ")"
-;  "{" "}"
 ] @bracket
 
 [
@@ -80,11 +79,11 @@
   name: (word) @identifier.variable)
 
 
-(targets) @identifier.function
+(targets) @processing.directive
 (rule
   target: (_) @string-template) 
 
 (recipe_line
   ["@" "-" "+"] @keyword.modifier) 
   
-(prerequisites) @identifier.function
+(prerequisites) @processing.argument

--- a/Queries/injections.scm
+++ b/Queries/injections.scm
@@ -1,0 +1,3 @@
+((recipe_line
+  (shell_text) @injection.content)
+ (#set! injection.language "shell"))

--- a/Queries/symbols.scm
+++ b/Queries/symbols.scm
@@ -1,0 +1,8 @@
+((rule
+  (targets) @name
+  (recipe) @subtree 
+ ) 
+ (#set! role function)  
+ (#set! scope.extend)
+ (#set! scope.byLine)
+) 

--- a/Syntaxes/Makefile.xml
+++ b/Syntaxes/Makefile.xml
@@ -18,6 +18,12 @@
         </single>
     </comments>
     
+    <indentation>
+        <increase>
+            <expression>(^[^\s][^:]*?:(?!=).*)</expression>
+        </increase>
+    </indentation>
+    
     <tree-sitter language="makefile">
         <highlights path="highlights.scm" />
     </tree-sitter>

--- a/Syntaxes/Makefile.xml
+++ b/Syntaxes/Makefile.xml
@@ -26,5 +26,6 @@
     
     <tree-sitter language="makefile">
         <highlights path="highlights.scm" />
+        <injections path="injections.scm" />
     </tree-sitter>
 </syntax>

--- a/Syntaxes/Makefile.xml
+++ b/Syntaxes/Makefile.xml
@@ -17,15 +17,16 @@
             <expression>#</expression>
         </single>
     </comments>
-    
+
     <indentation>
         <increase>
             <expression>(^[^\s][^:]*?:(?!=).*)</expression>
         </increase>
     </indentation>
-    
+
     <tree-sitter language="makefile">
-        <highlights path="highlights.scm" />
-        <injections path="injections.scm" />
+        <highlights/>
+        <injections/>
+        <symbols/>
     </tree-sitter>
 </syntax>

--- a/Syntaxes/Makefile.xml
+++ b/Syntaxes/Makefile.xml
@@ -12,6 +12,12 @@
         <match-content lines="1" priority="0.7">\#\!.*?\bmake\b</match-content>
     </detectors>
 
+    <comments>
+        <single>
+            <expression>#</expression>
+        </single>
+    </comments>
+    
     <tree-sitter language="makefile">
         <highlights path="highlights.scm" />
     </tree-sitter>


### PR DESCRIPTION
This PR adds a pair of definitions to the syntax's definition xml:
1. it sets the comment character to `#` which enables the keyboard shortcut for toggling comments
2. it adds a regex that watches for lines that look like recipe names (starting with no indentation and containing a colon) and increases the indentation by one step on the next line when the user types return

Fixes #1 

#### Additional enhancements
- adds an injection query to let the shell-script syntax module handle highlighting within recipes
- rules are now symbolicated so they'll appear in the Symbols sidebar and the `target: prerequisites` line will become a sticky header as you scroll through the file